### PR TITLE
Fix exporter 

### DIFF
--- a/loglan_core/addons/export_word_converter.py
+++ b/loglan_core/addons/export_word_converter.py
@@ -48,7 +48,7 @@ class ExportWordConverter:
         """
         notes: dict[str, str] = self.word.notes or {}
         if self.word.year:
-            return f"{self.word.year.year}{notes.get('year', str())}".strip()
+            return f"{self.word.year.year} {notes.get('year', str())}".strip()
         return ""
 
     @property

--- a/loglan_core/addons/exporter.py
+++ b/loglan_core/addons/exporter.py
@@ -121,7 +121,7 @@ class Exporter:
         Returns:
             tuple: elements for export
         """
-        return obj.name, obj.type, obj.allowed
+        return obj.name, obj.type, str(obj.allowed)
 
     @staticmethod
     def export_setting(obj: BaseSetting) -> tuple:
@@ -150,7 +150,7 @@ class Exporter:
             obj.type,
             obj.type_x,
             obj.group,
-            obj.parentable,
+            str(obj.parentable),
             obj.description,
         )
 

--- a/loglan_core/syllable.py
+++ b/loglan_core/syllable.py
@@ -33,7 +33,7 @@ class BaseSyllable(BaseModel):
         self,
         name: Mapped[str_008],
         type: Mapped[str_032],  # pylint: disable=W0622
-        allowed: Mapped[bool] | None = None,
+        allowed: Mapped[bool],
     ):
         super().__init__()
         self.name = name
@@ -56,6 +56,6 @@ class BaseSyllable(BaseModel):
     type: Mapped[str_032] = mapped_column(nullable=False)
     """*Syllable's type*  
             **str** : max_length=8, nullable=False, unique=False"""
-    allowed: Mapped[bool | None] = mapped_column(nullable=True)
+    allowed: Mapped[bool] = mapped_column(nullable=False)
     """*Is this syllable acceptable in grammar*  
-            **bool** : nullable=True, unique=False"""
+            **bool** : nullable=False, unique=False"""


### PR DESCRIPTION
Fix ExportWordConverter.e_year method (add space)
Fix output bool values for export_syllable and export_type Exporter methods
Fix BaseSyllable.allowed field (nullable=False)